### PR TITLE
fix(Dockerfile): remove config file from being added

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,5 +17,4 @@ RUN go run cmd/mage/main.go backend:genFrontend backend:genMigrations backend:bu
 FROM alpine:latest
 WORKDIR /root/
 COPY --from=backend /usr/src/app/dist/taskcafe .
-COPY --from=backend /usr/src/app/conf/app.example.toml conf/app.toml
 CMD ["./taskcafe", "web"]


### PR DESCRIPTION
because config settings can now be set through ENV variables or cli flag, we should no longer load a default config file in the dockerfile

let the user decide if they want to load one through volumes